### PR TITLE
Increase diagnostic logging period from 10 seconds to 20 seconds.

### DIFF
--- a/Assets/Scenes/Familiar.unity
+++ b/Assets/Scenes/Familiar.unity
@@ -590,8 +590,8 @@ MonoBehaviour:
   DynamicPrefabs: []
   DynamicMaterials:
   - {fileID: 2100000, guid: 1a8923ee8a981224aaa0e1bb297da0f3, type: 2}
-  - {fileID: 2100000, guid: 9a7f20c75aee3bc43bcf4b5321b9c7a2, type: 2}
   - {fileID: 2100000, guid: 98a40125dab96944bbe816425bd959aa, type: 2}
+  - {fileID: 2100000, guid: 9a7f20c75aee3bc43bcf4b5321b9c7a2, type: 2}
   - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
   LightMapsNear: []
   LightMapsFar: []

--- a/Assets/SynMediaPlayer/Logic/MediaPlayer.cs
+++ b/Assets/SynMediaPlayer/Logic/MediaPlayer.cs
@@ -139,7 +139,7 @@ namespace Synergiance.MediaPlayer {
 		private string debugPrefix         = "[<color=#DF004F>SynMediaPlayer</color>] ";
 
 		private float diagnosticsUpdatePeriod = 0.1f; // Update period of diagnostic display
-		private float diagnosticPeriod = 10;          // Period of diagnostic log
+		private float diagnosticPeriod = 20;          // Period of diagnostic log
 		private int   diagnosticUpdatesPerLog = 5;
 		private float diagnosticDelay = 0.25f;        // Delay between diagnostic logs
 


### PR DESCRIPTION
Nothing to say here really, I felt that 10 seconds was a bit short for diagnostics, given the 5s waiting periods for loading videos.
This will give longer logs but it should be worth it, and easier to trace